### PR TITLE
docs: fix typos and improve formatting in README

### DIFF
--- a/CODE_OF_CONDUCT_CN.md
+++ b/CODE_OF_CONDUCT_CN.md
@@ -47,7 +47,7 @@
 
 社区影响指南受到了[Mozilla 的行为准则执行阶梯][mozilla coc]的启发。
 
-有关本行为准则的常见问题，请参阅[FAQ][https://www.contributor-covenant.org/faq]。翻译版本可在[https://www.contributor-covenant.org/translations][translations]获取。
+有关本行为准则的常见问题，请参阅 [FAQ][faq]。翻译版本可在 [translations][translations] 获取。
 
 [homepage]: https://www.contributor-covenant.org
 [version]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/modules/atom01_deploy/README.md
+++ b/modules/atom01_deploy/README.md
@@ -108,7 +108,7 @@ source install/setup.bash
 ros2 launch hipnuc_imu imu_spec_msg.launch.py
 ```
 
-If IMU serial port permissions are normal, you can see IMU data using plotjunggler or ros2 topic echo.
+If IMU serial port permissions are normal, you can see IMU data using PlotJuggler or `ros2 topic echo`.
 
 ### MOTORS
 
@@ -137,13 +137,13 @@ ros2 service call /set_zeros motors/srv/SetZeros
 
 Observe that the motor green lights turn off one by one, indicating zeroing is in progress.
 
-After zeroing is complete, restart motors and open plotjunggler, subscribe to motor state topics and input:
+After zeroing is complete, restart motors and open PlotJuggler, subscribe to motor state topics and input:
 
 ```bash
 ros2 service call /read_motors motors/srv/ReadMotors
 ```
 
-At this time, you can see the current position of each motor in plotjunggler. Ensure there are no reversed joints and all are near zero point, then input:
+At this time, you can see the current position of each motor in PlotJuggler. Ensure there are no reversed joints and all are near zero point, then input:
 
 ```bash
 ros2 service call /reset_motors motors/srv/ResetMotors

--- a/modules/atom01_deploy/README_CN.md
+++ b/modules/atom01_deploy/README_CN.md
@@ -56,7 +56,7 @@ orangepi   -   memlock  unlimited
 
 保存退出后重启香橙派使设置生效。
 
-## 硬件链接
+## 硬件连接
 
 电机驱动中can0对应左腿，can1对应右腿加腰，can2对应左手，can3对应右手，默认按照usb转can插入上位机顺序编号，先插入的是can0。建议将USB转CAN插在上位机的3.0接口上，如果使用USB扩展坞也请使用3.0接口的USB扩展坞并插在3.0接口上，IMU和手柄插在USB2.0接口即可。
 
@@ -108,7 +108,7 @@ source install/setup.bash
 ros2 launch hipnuc_imu imu_spec_msg.launch.py
 ```
 
-如果IMU串口权限正常，使用plotjunggler或者ros2 topic echo可以看到IMU数据。
+如果IMU串口权限正常，使用 PlotJuggler 或者 `ros2 topic echo` 可以看到IMU数据。
 
 ### MOTORS
 
@@ -137,13 +137,13 @@ ros2 service call /set_zeros motors/srv/SetZeros
 
 观察到电机绿灯一个个灭下说明正在标零。
 
-标零完成后重新启动motors并打开plotjunggler，订阅电机state话题后输入：
+标零完成后重新启动 motors 并打开 PlotJuggler，订阅电机 state 话题后输入：
 
 ```bash
 ros2 service call /read_motors motors/srv/ReadMotors
 ```
 
-此时在plotjunggler中可以看到各个电机此时位置，保证没有反向关节且都在零点附近后输入：
+此时在 PlotJuggler 中可以看到各个电机此时位置，保证没有反向关节且都在零点附近后输入：
 
 ```bash
 ros2 service call /reset_motors motors/srv/ResetMotors

--- a/modules/atom01_description/README.md
+++ b/modules/atom01_description/README.md
@@ -1,3 +1,5 @@
-There are the description files of Atom01, a product of Roboparty.
+# Atom01 Description
 
-![Atom01 URDF 模型](atom01_urdf.png)  
+These are the description files of Atom01, a product of Roboparty.
+
+![Atom01 URDF](atom01_urdf.png)

--- a/modules/atom01_train/README_CN.md
+++ b/modules/atom01_train/README_CN.md
@@ -48,6 +48,7 @@ pip install -e .
 cd ..
 cd rsl_rl
 pip install -e .
+cd ..
 ```
 
 - 通过运行以下命令验证扩展是否正确安装，打印可用环境列表：


### PR DESCRIPTION
## Changes
- Fix typo: "硬件链接" → "硬件连接" (Hardware Connection)
- Fix tool name spelling: "plotjunggler" → "PlotJuggler" (correct name of the ROS visualization tool)
- Improve formatting: add proper spacing in Chinese-English mixed text
- Format `ros2 topic echo` as inline code