### PR TITLE
docs: update repository names after migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,14 @@ If you wish to contribute to the project, please select the appropriate sub-repo
 
 | Sub-Repository                                                            | Contribution Areas                                                                         |
 | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| **[Atom01_hardware](https://github.com/Roboparty/Atom01_hardware)**       | Mechanical structure design, CAD drawings, PCB design, BOM improvements                    |
-| **[atom01_deploy](https://github.com/Roboparty/atom01_deploy)**           | ROS2 driver development, middleware modules, deployment configs, IMU/motor integration     |
-| **[atom01_train](https://github.com/Roboparty/atom01_train)**             | RL algorithms, training environments, simulation configs, Sim2Sim transfer                 |
-| **[atom01_description](https://github.com/Roboparty/atom01_description)** | URDF kinematic/dynamic descriptions, visual/collision meshes, joint parameter optimization |
-| **[atom01_firmware](https://github.com/Roboparty/atom01_firmware)**       | Firmware development, embedded software, USB2CAN, OrangePi build system, system daemon management |
-| **[atom01_appearance](https://github.com/Roboparty/atom01_appearance)**   | Exterior shell design, appearance structure, visual references, surface and assembly notes. Static Display Only; Printing Not Recommended |
+| **[rpo_hardware](https://github.com/Roboparty/rpo_hardware)**             | RPO mechanical structure design, CAD drawings, PCB design, BOM improvements                |
+| **[roboparty_deploy](https://github.com/Roboparty/roboparty_deploy)**     | ROS2 deployment framework, middleware modules, deployment configs, IMU/motor integration   |
+| **[roboparty_train](https://github.com/Roboparty/roboparty_train)**       | RL algorithms, training environments, simulation configs, Sim2Sim transfer                 |
+| **[rpo_description](https://github.com/Roboparty/rpo_description)**       | RPO URDF/MJCF kinematic and dynamic descriptions, visual/collision meshes                 |
+| **[roboparty_firmware](https://github.com/Roboparty/roboparty_firmware)** | Firmware development, embedded software, USB2CAN, OrangePi/RDK build tooling              |
+| **[rpo_appearance](https://github.com/Roboparty/rpo_appearance)**         | RPO exterior shell design assets and prototype enclosure documentation. Static Display Only; Printing Not Recommended |
+
+**Compatibility note:** Some snapshot paths under `modules/...` still use the historical Atom01/atom01 directory names during the naming transition.
 
 **For detailed contribution guidelines:** [CONTRIBUTING.md](CONTRIBUTING.md)
 
@@ -60,12 +62,12 @@ If you wish to contribute to the project, please select the appropriate sub-repo
 
 | Module Name            | Description                                                                                                                                               | Repository Link                                 |
 | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
-| **Atom01_hardware**    | Hardware design files for Atom01 robot, including structural drawings and design materials                                                                | https://github.com/Roboparty/Atom01_hardware    |
-| **atom01_deploy**      | ROS2 deployment framework with modular architecture middleware for robot deployment and control, supporting IMU, motor drivers, inference, etc.           | https://github.com/Roboparty/atom01_deploy      |
-| **atom01_train**       | Direct IsaacLab training workflow providing high transparency and low refactoring difficulty RL training environment, supports Sim2Sim transfer to MuJoCo | https://github.com/Roboparty/atom01_train       |
-| **atom01_description** | URDF model files for Atom01 robot, containing kinematic and dynamic descriptions for simulation and visualization                                         | https://github.com/Roboparty/atom01_description |
-| **atom01_firmware**    | Firmware module for Atom01 robot, providing embedded software support including USB2CAN, OrangePi build system, and system daemon management              | https://github.com/Roboparty/atom01_firmware    |
-| **atom01_appearance**  | Appearance design files for Atom01 robot, including exterior shell design assets and prototype enclosure documentation.Static Display Only; Printing Not Recommended  | https://github.com/Roboparty/atom01_appearance  |
+| **rpo_hardware**        | Hardware design files for the RPO robot, including structural drawings and design materials                                                              | https://github.com/Roboparty/rpo_hardware       |
+| **roboparty_deploy**    | ROS2 deployment framework with modular architecture middleware for robot deployment and control, supporting IMU, motor drivers, inference, etc.           | https://github.com/Roboparty/roboparty_deploy   |
+| **roboparty_train**     | Direct IsaacLab training workflow providing high transparency and low refactoring difficulty RL training environment, supports Sim2Sim transfer to MuJoCo | https://github.com/Roboparty/roboparty_train    |
+| **rpo_description**     | RPO URDF/MJCF model files containing kinematic and dynamic descriptions for simulation and visualization                                                 | https://github.com/Roboparty/rpo_description    |
+| **roboparty_firmware**  | Firmware module providing embedded software support including USB2CAN, OrangePi/RDK build tooling, and system daemon management                           | https://github.com/Roboparty/roboparty_firmware |
+| **rpo_appearance**      | RPO appearance design files, including exterior shell design assets and prototype enclosure documentation. Static Display Only; Printing Not Recommended  | https://github.com/Roboparty/rpo_appearance     |
 
 ---
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -51,12 +51,14 @@
 
 | 子仓库                                                                    | 贡献方向                                           |
 | ------------------------------------------------------------------------- | -------------------------------------------------- |
-| **[Atom01_hardware](https://github.com/Roboparty/Atom01_hardware)**       | 机械结构设计、CAD图纸、PCB设计、BOM改进            |
-| **[atom01_deploy](https://github.com/Roboparty/atom01_deploy)**           | ROS2驱动开发、中间件模块、部署配置、IMU/电机集成   |
-| **[atom01_train](https://github.com/Roboparty/atom01_train)**             | 强化学习算法、训练环境、仿真配置、Sim2Sim迁移      |
-| **[atom01_description](https://github.com/Roboparty/atom01_description)** | URDF运动学/动力学描述、视觉/碰撞网格、关节参数优化 |
-| **[atom01_firmware](https://github.com/Roboparty/atom01_firmware)**       | 固件开发、嵌入式软件、USB2CAN、OrangePi构建系统、系统守护进程管理 |
-| **[atom01_appearance](https://github.com/Roboparty/atom01_appearance)**   | 外观件设计、外壳结构、视觉参考、表面处理与装配说明，仅供静态展示，不建议打印 |
+| **[rpo_hardware](https://github.com/Roboparty/rpo_hardware)**             | RPO 机械结构设计、CAD图纸、PCB设计、BOM改进        |
+| **[roboparty_deploy](https://github.com/Roboparty/roboparty_deploy)**     | ROS2驱动开发、中间件模块、部署配置、IMU/电机集成   |
+| **[roboparty_train](https://github.com/Roboparty/roboparty_train)**       | 强化学习算法、训练环境、仿真配置、Sim2Sim迁移      |
+| **[rpo_description](https://github.com/Roboparty/rpo_description)**       | RPO URDF/MJCF运动学/动力学描述、视觉/碰撞网格      |
+| **[roboparty_firmware](https://github.com/Roboparty/roboparty_firmware)** | 固件开发、嵌入式软件、USB2CAN、OrangePi/RDK构建工具、系统守护进程管理 |
+| **[rpo_appearance](https://github.com/Roboparty/rpo_appearance)**         | RPO 外观件设计、外壳结构、视觉参考、表面处理与装配说明，仅供静态展示，不建议打印 |
+
+**兼容说明：** 命名迁移期间，快照目录 `modules/...` 下的部分路径仍保留历史 Atom01/atom01 目录名。
 
 **详细贡献指南请点击这里：** [CONTRIBUTING_CN.md](CONTRIBUTING_CN.md)
 
@@ -81,12 +83,12 @@
 
 | 模块名称               | 介绍                                                                                              | 仓库链接                                        |
 | ---------------------- | ------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
-| **Atom01_hardware**    | Atom01机器人的硬件设计文件，包含结构图纸和设计资料                                                | https://github.com/Roboparty/Atom01_hardware    |
-| **atom01_deploy**      | ROS2部署框架，提供模块化架构的中间件，用于机器人部署和控制，支持IMU、电机驱动、推理等功能         | https://github.com/Roboparty/atom01_deploy      |
-| **atom01_train**       | 基于IsaacLab的直接训练工作流，提供高透明度和低重构难度的强化学习训练环境，支持Sim2Sim迁移到MuJoCo | https://github.com/Roboparty/atom01_train       |
-| **atom01_description** | Atom01机器人的URDF模型文件，包含机器人运动学和动力学描述，用于仿真和可视化                        | https://github.com/Roboparty/atom01_description |
-| **atom01_firmware**    | Atom01机器人的固件模块，提供嵌入式软件支持，包括USB2CAN、OrangePi构建系统和系统守护进程管理         | https://github.com/Roboparty/atom01_firmware    |
-| **atom01_appearance**  | Atom01机器人的外观设计文件，包含外观件、外壳设计资料和原型机外观说明，仅供静态展示，不建议打印                              | https://github.com/Roboparty/atom01_appearance  |
+| **rpo_hardware**        | RPO 机器人的硬件设计文件，包含结构图纸和设计资料                                                  | https://github.com/Roboparty/rpo_hardware       |
+| **roboparty_deploy**    | ROS2部署框架，提供模块化架构的中间件，用于机器人部署和控制，支持IMU、电机驱动、推理等功能         | https://github.com/Roboparty/roboparty_deploy   |
+| **roboparty_train**     | 基于IsaacLab的直接训练工作流，提供高透明度和低重构难度的强化学习训练环境，支持Sim2Sim迁移到MuJoCo | https://github.com/Roboparty/roboparty_train    |
+| **rpo_description**     | RPO 机器人的URDF/MJCF模型文件，包含机器人运动学和动力学描述，用于仿真和可视化                    | https://github.com/Roboparty/rpo_description    |
+| **roboparty_firmware**  | 固件模块，提供嵌入式软件支持，包括USB2CAN、OrangePi/RDK构建工具和系统守护进程管理                 | https://github.com/Roboparty/roboparty_firmware |
+| **rpo_appearance**      | RPO 机器人的外观设计文件，包含外观件、外壳设计资料和原型机外观说明，仅供静态展示，不建议打印      | https://github.com/Roboparty/rpo_appearance     |
 
 ---
 

--- a/RENAME_PLAN.md
+++ b/RENAME_PLAN.md
@@ -30,14 +30,14 @@ ownership should be tracked in private project management channels.
 
 | Old repository | New repository | Status | Notes |
 | --- | --- | --- | --- |
-| `Atom01_hardware` | `rpo_hardware` | Pending | Old repo still active as of 2026-05-28. |
+| `Atom01_hardware` | `rpo_hardware` | Done | GitHub repo renamed. Snapshot path is retained for compatibility. |
 | `atom01_appearance` | `rpo_appearance` | Done | GitHub repo renamed. README migrated to RPO wording. STL filenames kept for compatibility. |
 | `atom01_description` | `rpo_description` | Done, needs confirmation | GitHub repo rename observed. Internal model/path migration status needs confirmation. |
 | `atom01_deploy` | `roboparty_deploy` | Done, needs confirmation | GitHub repo rename observed. RPO-specific configs should remain documented as the current default. |
-| `atom01_firmware` | `roboparty_firmware` | Pending | Old repo still active as of 2026-05-28. Forked/vendor code must preserve upstream names and licenses. |
+| `atom01_firmware` | `roboparty_firmware` | Done, needs confirmation | GitHub repo rename observed. Forked/vendor code must preserve upstream names and licenses. |
 | `atom01_train` | `roboparty_train` | Done, needs confirmation | GitHub repo rename observed. RPO-specific training assets should move under explicit product paths over time. |
 | `atom01_navigation` | `roboparty_navigation` | Done, needs confirmation | GitHub repo rename observed. Default branch is `master`. |
-| `Atom_xr_teleop` | TBD | Pending | Decide between `roboparty_xr_teleop` and product-specific naming. |
+| `Atom_xr_teleop` | TBD | Deferred | Not part of the current migration batch. |
 
 ## Migration Phases
 


### PR DESCRIPTION
## Summary
- Update README and README_cn repository tables to the new rpo_* and roboparty_* names.
- Mark rpo_hardware and roboparty_firmware as renamed in the public migration plan.
- Mark Atom_xr_teleop as deferred for this migration batch.

## Notes
- Tracked documentation only.
- modules/... snapshot paths are intentionally not renamed in this phase.
- .scripts remains a local untracked operations directory and is not part of this PR.
